### PR TITLE
Add vm name to extraconfig and leverage vmware_lib for clone_vm

### DIFF
--- a/py_vmware/register_vm.py
+++ b/py_vmware/register_vm.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+"""
+Written by Matt kirby
+github: https://github.com/mattkirby
+Email: kirby@puppet.com
+Register VM to a target folder by storage path
+"""
+import argparse
+import py_vmware.vmware_lib as vmware_lib
+import getpass
+import sys
+from tools import tasks
+
+
+def get_args():
+    """ Get arguments from CLI """
+    parser = argparse.ArgumentParser(
+        description='Arguments for talking to vCenter')
+
+    parser.add_argument('-s', '--host',
+                        required=True,
+                        action='store',
+                        help='vSphere service to connect to')
+
+    parser.add_argument('-o', '--port',
+                        type=int,
+                        default=443,
+                        action='store',
+                        help='Port to connect on')
+
+    parser.add_argument('-u', '--user',
+                        required=True,
+                        action='store',
+                        help='Username to use')
+
+    parser.add_argument('-p', '--password',
+                        required=False,
+                        action='store',
+                        help='Password to use')
+
+    parser.add_argument('-v', '--vm-name',
+                        required=True,
+                        action='store',
+                        help='Name of the VM to register')
+
+    parser.add_argument('--vm-path',
+                        required=False,
+                        action='store',
+                        help='Full path to VM')
+
+    parser.add_argument('--datacenter-name',
+                        required=False,
+                        action='store',
+                        default=None,
+                        help='Name of the Datacenter you\
+                            wish to use. If omitted, the first\
+                            datacenter will be used.')
+
+    parser.add_argument('--vm-folder',
+                        required=True,
+                        action='store',
+                        help='Name of the target folder')
+
+    parser.add_argument('--datastore-name',
+                        required=True,
+                        action='store',
+                        help='Datastore to find the target VM')
+
+    parser.add_argument('--cluster-name',
+                        required=True,
+                        action='store',
+                        help='Target cluster for VM registration')
+
+    parser.add_argument('-i', '--insecure',
+                        required=False,
+                        action='store_true',
+                        help='disable ssl validation')
+
+    args = parser.parse_args()
+
+    if not args.password:
+        args.password = getpass.getpass(
+            prompt='Enter password')
+
+    return args
+
+
+def main():
+    args = get_args()
+
+    si = vmware_lib.connect(args.host, args.user, args.password, args.port, args.insecure)
+    content = si.RetrieveContent()
+
+    folder = vmware_lib.get_obj(content, [vmware_lib.vim.Folder], args.vm_folder)
+    if not folder:
+        print 'Cannot find folder {}'.format(args.vm_folder)
+        sys.exit(1)
+
+    cluster = vmware_lib.get_obj(content, [vmware_lib.vim.ClusterComputeResource], args.cluster_name)
+    if not cluster:
+        print 'Cannot find cluster {}'.format(args.cluster_name)
+        sys.exit(1)
+
+    resource_pool = cluster.resourcePool
+    if args.vm_path:
+        full_path = args.vm_path
+    else:
+        full_path = '{}/{}.vmx'.format(args.vm_name, args.vm_name)
+    datastore_path = '[{}] {}'.format(args.datastore_name, full_path)
+
+    print 'Registering {}'.format(args.vm_name)
+    folder.RegisterVm(datastore_path, args.vm_name, False, resource_pool)
+
+# start this thing
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='py_vmware',
-    version='0.0.17',
+    version='0.0.18',
     packages=find_packages(),
     install_requires=['pyvmomi'],
     entry_points={
@@ -18,6 +18,7 @@ setup(
             'vmware_vm_snapshot = py_vmware.vm_snapshot:main',
             'vmware_mount_datastore = py_vmware.add_cluster_datastore:main',
             'vmware_empty_datastore = py_vmware.empty_datastore:main',
+            'vmware_register_vm = py_vmware.register_vm:main',
         ]
     },
     author='Matt Kirby',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='py_vmware',
-    version='0.0.16',
+    version='0.0.17',
     packages=find_packages(),
     install_requires=['pyvmomi'],
     entry_points={


### PR DESCRIPTION
This commit updates clone_vm to use vmware_lib for connection
components. Additionally, extraconfig now gets populated with VM
name, which makes it possible to leverage boostrapping scripts that
expect to find this data for automatic naming of deployed VMs.
Additionally, a capability is added to explicitly identify the parent
folder of your folder target. Without this change it's possible to
select a different folder than expected when there is more than one
folder of that title in inventory. Additionally, without this change,
machines configured to find data about their name upon first boot, and
configure themselves with that name, will not work.