### PR TITLE
(QENG-5514:WIP) spike changes

### DIFF
--- a/py_vmware/destroy_vm.py
+++ b/py_vmware/destroy_vm.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+
 # Copyright 2015 Michael Rice <michael@michaelrice.org>
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,10 +19,9 @@ from __future__ import print_function
 import atexit
 
 import requests
-from pyVim import connect
-
-from tools import cli
-from tools import tasks
+from py_vmware.tools import cli
+from py_vmware.tools import tasks
+import py_vmware.vmware_lib as vmware_lib
 
 requests.packages.urllib3.disable_warnings()
 
@@ -34,52 +34,74 @@ def setup_args():
     # using j here because -u is used for user
     parser.add_argument('-j', '--uuid',
                         help='BIOS UUID of the VirtualMachine you want to destroy.')
-    parser.add_argument('-n', '--name',
+    parser.add_argument('-n', '--vm-name',
                         help='DNS Name of the VirtualMachine you want to destroy.')
     parser.add_argument('-i', '--ip',
                         help='IP Address of the VirtualMachine you want to destroy')
+    # empty values
+    parser.add_argument('--template',
+                        action='store',
+                        help='Name of the template/VM \
+                            you are cloning from')
+    parser.add_argument('--vm-folder',
+                        required=False,
+                        action='store',
+                        default=None,
+                        help='Name of the VMFolder you wish\
+                            the VM to be dumped in. If left blank\
+                            The datacenter VM folder will be used')
 
     my_args = parser.parse_args()
 
     return cli.prompt_for_password(my_args)
 
 
-ARGS = setup_args()
-SI = None
-try:
-    SI = connect.SmartConnect(host=ARGS.host,
-                              user=ARGS.user,
-                              pwd=ARGS.password,
-                              port=ARGS.port)
-    atexit.register(connect.Disconnect, SI)
-except IOError, ex:
-    pass
+def main():
+    ARGS = setup_args()
+    SI = None
+    try:
+        SI = vmware_lib.connect(
+            ARGS.host,
+            ARGS.user,
+            ARGS.password,
+            ARGS.port,
+            ARGS.insecure
+        )
+        print("- connected to vmware")
+    except IOError as ex:
+        print("IOError: %s" % ex.message)
+        pass
+    
+    if not SI:
+        raise SystemExit("Unable to connect to host with supplied info.")
+    VM = None
+    if ARGS.uuid:
+        print("- looking for VM by UUID: %s" % ARGS.uuid)
+        VM = SI.content.searchIndex.FindByUuid(
+            None, ARGS.uuid, True, False)
+    elif ARGS.vm_name:
+        print("- looking for VM by DNS Name: %s" % ARGS.vm_name)
+        VM = SI.content.searchIndex.FindByDnsName(
+            None, ARGS.vm_name, True)
+    elif ARGS.ip:
+        print("- looking for VM by IP: %s" % ARGS.ip)
+        VM = SI.content.searchIndex.FindByIp(None, ARGS.ip, True)
 
-if not SI:
-    raise SystemExit("Unable to connect to host with supplied info.")
-VM = None
-if ARGS.uuid:
-    VM = SI.content.searchIndex.FindByUuid(None, ARGS.uuid,
-                                           True,
-                                           False)
-elif ARGS.name:
-    VM = SI.content.searchIndex.FindByDnsName(None, ARGS.name,
-                                              True)
-elif ARGS.ip:
-    VM = SI.content.searchIndex.FindByIp(None, ARGS.ip, True)
+    if VM is None:
+        raise SystemExit("Unable to locate VirtualMachine.")
+    
+    print("Found: {0}".format(VM.name))
+    print("The current powerState is: {0}".format(VM.runtime.powerState))
+    if format(VM.runtime.powerState) == "poweredOn":
+        print("Attempting to power off {0}".format(VM.name))
+        TASK = VM.PowerOffVM_Task()
+        tasks.wait_for_tasks(SI, [TASK])
+        print("{0}".format(TASK.info.state))
+        
+        print("Destroying VM from vSphere.")
+        TASK = VM.Destroy_Task()
+        tasks.wait_for_tasks(SI, [TASK])
+        print("Done.")
 
-if VM is None:
-    raise SystemExit("Unable to locate VirtualMachine.")
-
-print("Found: {0}".format(VM.name))
-print("The current powerState is: {0}".format(VM.runtime.powerState))
-if format(VM.runtime.powerState) == "poweredOn":
-    print("Attempting to power off {0}".format(VM.name))
-    TASK = VM.PowerOffVM_Task()
-    tasks.wait_for_tasks(SI, [TASK])
-    print("{0}".format(TASK.info.state))
-
-print("Destroying VM from vSphere.")
-TASK = VM.Destroy_Task()
-tasks.wait_for_tasks(SI, [TASK])
-print("Done.")
+if __name__ == '__main__':
+    main()

--- a/py_vmware/tools/cli.py
+++ b/py_vmware/tools/cli.py
@@ -32,8 +32,16 @@ def build_arg_parser():
     -p optional_password
 
     """
-    parser = argparse.ArgumentParser(
-        description='Standard Arguments for talking to vCenter')
+    import configargparse as cap
+    parser = cap.ArgParser(default_config_files=['./env.py.list'],
+        description='Arguments for talking to vCenter')
+    # parser = argparse.ArgumentParser(
+    #     description='Standard Arguments for talking to vCenter')
+
+    parser.add_argument('-c', '--my-config',
+                        required=True,
+                        is_config_file=True,
+                        help='config file path')
 
     # because -h is reserved for 'help' we use -s for service
     parser.add_argument('-s', '--host',
@@ -57,6 +65,20 @@ def build_arg_parser():
                         required=False,
                         action='store',
                         help='Password to use when connecting to host')
+
+    parser.add_argument('--insecure',
+                        required=False,
+                        action='store_true',
+                        help='disable ssl validation')
+
+    parser.add_argument('--datacenter-name',
+                        required=False,
+                        action='store',
+                        default=None,
+                        help='Name of the Datacenter you\
+                            wish to use. If omitted, the first\
+                            datacenter will be used.')
+
     return parser
 
 

--- a/py_vmware/vmware_lib.py
+++ b/py_vmware/vmware_lib.py
@@ -20,7 +20,7 @@ def wait_for_task(task):
             return task.info.result
 
         if task.info.state == 'error':
-            print "there was an error - {}".format(task.info.error.msg)
+            print("there was an error - {}".format(task.info.error.msg))
             task_done = True
 
 def get_obj(content, vimtype, name):
@@ -40,6 +40,7 @@ def get_obj(content, vimtype, name):
             obj = c
             break
 
+    print("- vmware_lib.get_obj: type: %s, name: %s, found: %s" % (vimtype[0], name, obj.name))
     return obj
 
 def migrate_vm(content, virtual_machine, rebalance, limit):
@@ -52,8 +53,8 @@ def migrate_vm(content, virtual_machine, rebalance, limit):
         if target_host_name == current_host_name:
             return "{} is already located on the optimal host.".format(vm.name)
         else:
-            print "Migrating {} from {} to {}".format(
-                vm.name, current_host_name, target_host_name)
+            print("Migrating {} from {} to {}".format(
+                vm.name, current_host_name, target_host_name))
             move_vm(vm, target)
             return True
     else:
@@ -116,25 +117,25 @@ def maintenance_mode(host, state):
     """
     if state:
         if not host.runtime.inMaintenanceMode:
-            print 'Placing {} into maintenance mode'.format(host.name)
+            print('Placing {} into maintenance mode'.format(host.name))
             wait_for_task(host.EnterMaintenanceMode(0))
         else:
-            print '{} is already in maintenance mode'.format(host.name)
+            print('{} is already in maintenance mode'.format(host.name))
     elif state == False:
         if host.runtime.inMaintenanceMode:
-            print 'Exiting maintenance mode'
+            print('Exiting maintenance mode')
             wait_for_task(host.ExitMaintenanceMode(0))
         else:
-            print '{} is not in maintenance mode'.format(host.name)
+            print('{} is not in maintenance mode'.format(host.name))
 
 def reconnect_host(host, user, pwd):
     """
     Reconnect a ESXi host to vcenter
     """
     if host.summary.runtime.connectionState == 'connected':
-        print '{} is already connected'.format(host.name)
+        print('{} is already connected'.format(host.name))
     elif host.summary.runtime.connectionState == 'disconnected':
-        print 'Reconnecting {}'.format(host.name)
+        print('Reconnecting {}'.format(host.name))
         connectspec = vim.host.ConnectSpec()
         connectspec.userName, connectspec.password = user, pwd
         wait_for_task(host.Reconnect(connectspec))
@@ -179,7 +180,7 @@ def migrate_host_vms(content, host, skip, rebalance, limit):
                 if not vm.name in skip:
                     migrate = migrate_vm(content, vm, rebalance, limit)
                     if isinstance(migrate, str):
-                        print ' '.join([migrate, 'Skipping remaining VMs.'])
+                        print(' '.join([migrate, 'Skipping remaining VMs.']))
                         break
                     else:
                         migrate_count = migrate_count + 1
@@ -187,14 +188,14 @@ def migrate_host_vms(content, host, skip, rebalance, limit):
                 migrate = migrate_vm(content, vm, rebalance, limit)
                 if isinstance(migrate, str):
                     if not migrate == 'vm not found':
-                        print ' '.join([migrate, 'Skipping remaining VMs.'])
+                        print(' '.join([migrate, 'Skipping remaining VMs.']))
                         break
                 else:
                     migrate_count = migrate_count + 1
         if migrate_count > 1:
-            print 'Successfully migrated {} vms from {}'.format(migrate_count, host.name)
+            print('Successfully migrated {} vms from {}'.format(migrate_count, host.name))
     else:
-        print 'No vms found on {}'.format(host.name)
+        print('No vms found on {}'.format(host.name))
 
 def mount_datastore(specification, host):
     try:
@@ -235,6 +236,6 @@ def migrate_vm_datastore(vm, datastore):
     # set relospec
     relospec = vim.vm.RelocateSpec()
     relospec.datastore = datastore
-    print "Migrating {} to {}...".format(vm.name, datastore.name)
+    print("Migrating {} to {}...".format(vm.name, datastore.name))
     task = vm.Relocate(spec=relospec)
     wait_for_task(task)


### PR DESCRIPTION
@mattkirby these changes are the ones that I've made to run the spike for QENG-5514.

The reasons these changes were made are:
- print changes to run in python 3 rather than 2
- adding configargparse usage so that I can provide key-value pairs in a file rather than in command-line arguments
- needed to prefix local module usage with `py_vmware` in order for execution to work when installed from pip
- a few small changes to make what I suspect is older code use newer patterns I saw in other files (putting `destroy_vm.py`'s main functionality into a main method is the most obvious example)

I don't think you should except all of these changes, at least not right now at the same time like this. But I thought it would be good to bring them up here in their WIP form, so that we could have a discussion around whether or not they should be included. Once that's done I can munge the changes into a better form for actual submission & merging.