### PR TITLE
(maint) Update insecure connection protocol

### DIFF
--- a/py_vmware/vmware_lib.py
+++ b/py_vmware/vmware_lib.py
@@ -141,7 +141,7 @@ def reconnect_host(host, user, pwd):
 
 def connect(host, user, pwd, port, insecure):
     if insecure:
-        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         context.verify_mode = ssl.CERT_NONE
         si = SmartConnect(
                 host=host, user=user, pwd=pwd, port=port, sslContext=context)


### PR DESCRIPTION
The current connection protocol when passing the `--insecure` flag is tlsv1. This results in a handshake failure. 

According to [python docs ](https://docs.python.org/3/library/ssl.html#id4) we should change this to `PROTOCOL_TLS`