### PR TITLE
Retry putting a host in maint mode by default, adds "attempts" param

### DIFF
--- a/py_vmware/migrate_host_vms.py
+++ b/py_vmware/migrate_host_vms.py
@@ -95,7 +95,7 @@ def get_args():
 def retry(fun, max_tries=5):
     for i in range(max_tries):
         try:
-           time.sleep(0.3) 
+           time.sleep(0.3)
            fun()
            break
         except Exception:
@@ -146,4 +146,4 @@ def main():
 
 # start this thing
 if __name__ == "__main__":
-    rety(main())
+    retry(main())

--- a/py_vmware/migrate_host_vms.py
+++ b/py_vmware/migrate_host_vms.py
@@ -86,7 +86,7 @@ def get_args():
     parser.add_argument('--attempts',
                         action='store',
                         type=int,
-                        default=5,
+                        default=3,
                         help='Number of times to attempt the task')
 
     parser.add_argument('-e', '--esxi_host', action='store', help='host to migrate VMs from')
@@ -103,6 +103,7 @@ def main():
     Let this thing fly
     """
     args = get_args()
+    attempts_left = args.attempts - 1
     for i in range(args.attempts):
         try:
 
@@ -133,7 +134,7 @@ def main():
                         vmware_lib.migrate_host_vms(content, host, args.skip, args.rebalance, args.limit)
 
                     if args.maintenance_mode or args.maintenance_mode == False:
-                        vmware_lib.maintenance_mode(host, args.maintenance_mode)
+                        vmware_lib.maintenance_mode(host, args.maintenance_mode, attempts_left)
                     if args.reboot:
                         print 'Rebooting {}'.format(host.name)
                         vmware_lib.wait_for_task(host.Reboot(force=False))
@@ -144,6 +145,7 @@ def main():
                     sys.exit(1)
             break
         except RuntimeError:
+            attempts_left -= 1
             continue
 
 # start this thing

--- a/py_vmware/migrate_host_vms.py
+++ b/py_vmware/migrate_host_vms.py
@@ -3,6 +3,7 @@
 import argparse
 import py_vmware.vmware_lib as vmware_lib
 import sys
+import time
 from tools import tasks
 
 
@@ -91,6 +92,15 @@ def get_args():
     args = parser.parse_args()
     return args
 
+def retry(fun, max_tries=5):
+    for i in range(max_tries):
+        try:
+           time.sleep(0.3) 
+           fun()
+           break
+        except Exception:
+            continue
+
 def main():
     """
     Let this thing fly
@@ -136,4 +146,4 @@ def main():
 
 # start this thing
 if __name__ == "__main__":
-    main()
+    rety(main())

--- a/py_vmware/vmware_lib.py
+++ b/py_vmware/vmware_lib.py
@@ -117,13 +117,13 @@ def maintenance_mode(host, state):
     if state:
         if not host.runtime.inMaintenanceMode:
             print 'Placing {} into maintenance mode'.format(host.name)
-            wait_for_task(host.EnterMaintenanceMode(0))
+            wait_for_task(host.EnterMaintenanceMode(10))
         else:
             print '{} is already in maintenance mode'.format(host.name)
     elif state == False:
         if host.runtime.inMaintenanceMode:
             print 'Exiting maintenance mode'
-            wait_for_task(host.ExitMaintenanceMode(0))
+            wait_for_task(host.ExitMaintenanceMode(10))
         else:
             print '{} is not in maintenance mode'.format(host.name)
 

--- a/py_vmware/vmware_lib.py
+++ b/py_vmware/vmware_lib.py
@@ -111,7 +111,7 @@ def find_target_host(vm, content, rebalance, cpu_limit=75, memory_limit=80, limi
     except:
         return False
 
-def maintenance_mode(host, state):
+def maintenance_mode(host, state, attempts):
     """
     Enter a host into maintenance mode
     """
@@ -121,7 +121,10 @@ def maintenance_mode(host, state):
             host.EnterMaintenanceMode(10)
             time.sleep(10)
             if host.runtime.inMaintenanceMode == False:
-                print 'Failed to place host into maintenance mode'
+                if attempts > 0:
+                    print 'Failed to place host into maintenance mode, will retry {} more times'.format(attempts)
+                else:
+                    print 'Failed to place host into maintenance mode, giving up'
                 raise RuntimeError('Failed to enter maintenance mode')
         else:
             print '{} is already in maintenance mode'.format(host.name)

--- a/py_vmware/vmware_lib.py
+++ b/py_vmware/vmware_lib.py
@@ -8,6 +8,7 @@ import atexit
 import vmutils
 import ssl
 import sys
+import time
 
 def str2bool(v):
     return str(v.lower()) in ("yes", "true", "t", "1")
@@ -120,6 +121,7 @@ def maintenance_mode(host, state):
             host.EnterMaintenanceMode(10)
             time.sleep(10)
             if host.runtime.inMaintenanceMode == False:
+                print 'Failed to place host into maintenance mode'
                 raise RuntimeError('Failed to enter maintenance mode')
         else:
             print '{} is already in maintenance mode'.format(host.name)

--- a/py_vmware/vmware_lib.py
+++ b/py_vmware/vmware_lib.py
@@ -115,10 +115,12 @@ def maintenance_mode(host, state):
     Enter a host into maintenance mode
     """
     if state:
-        if not host.runtime.inMaintenanceMode:
+        if host.runtime.inMaintenanceMode == False:
             print 'Placing {} into maintenance mode'.format(host.name)
             host.EnterMaintenanceMode(10)
-            print 'Made it past enter maintenance mode'
+            time.sleep(10)
+            if host.runtime.inMaintenanceMode == False:
+                raise RuntimeError('Failed to enter maintenance mode')
         else:
             print '{} is already in maintenance mode'.format(host.name)
     elif state == False:

--- a/py_vmware/vmware_lib.py
+++ b/py_vmware/vmware_lib.py
@@ -117,13 +117,14 @@ def maintenance_mode(host, state):
     if state:
         if not host.runtime.inMaintenanceMode:
             print 'Placing {} into maintenance mode'.format(host.name)
-            wait_for_task(host.EnterMaintenanceMode(10))
+            host.EnterMaintenanceMode(10)
+            print 'Made it past enter maintenance mode'
         else:
             print '{} is already in maintenance mode'.format(host.name)
     elif state == False:
         if host.runtime.inMaintenanceMode:
             print 'Exiting maintenance mode'
-            wait_for_task(host.ExitMaintenanceMode(10))
+            host.ExitMaintenanceMode(10)
         else:
             print '{} is not in maintenance mode'.format(host.name)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='py_vmware',
-    version='0.0.18',
+    version='0.0.19',
     packages=find_packages(),
     install_requires=['pyvmomi'],
     entry_points={


### PR DESCRIPTION
In some cases putting a host in maintenance mode would fail, and the tool would stall at the CLI with no further output. 

This PR adds a timeout to this operation, checks that putting a host in maint. mode was successful or not and retries the operation if it fails.

It will retry 3 times by default with a parameter to override the number of retries if desired.